### PR TITLE
Handle ES6 Maps and Sets

### DIFF
--- a/javascript-stringify.js
+++ b/javascript-stringify.js
@@ -195,6 +195,16 @@
     '[object Uint8Array]': function (array, indent) {
       return 'new Uint8Array(' + stringifyArray(array) + ')';
     },
+    '[object Set]': function (array, indent, next) {
+      if (typeof Array.from === 'function') {
+        return 'new Set(' + stringify(Array.from(array), indent, next) + ')';
+      } else return undefined;
+    },
+    '[object Map]': function (array, indent, next) {
+      if (typeof Array.from === 'function') {
+        return 'new Map(' + stringify(Array.from(array), indent, next) + ')';
+      } else return undefined;
+    },
     '[object RegExp]': String,
     '[object Function]': String,
     '[object global]': toGlobalVariable,

--- a/test.js
+++ b/test.js
@@ -97,6 +97,21 @@ describe('javascript-stringify', function () {
       });
     });
 
+    describe('ES6', function () {
+      if (typeof Array.from === 'function') {
+        if (typeof Map !== 'undefined') {
+          describe('Map', function () {
+            it('should stringify', test(new Map([['key', 'value']]), "new Map([['key','value']])"));
+          });
+        }
+        if (typeof Set !== 'undefined') {
+          describe('Set', function () {
+            it('should stringify', test(new Set(['key', 'value']), "new Set(['key','value'])"));
+          });
+        }
+      }
+    });
+
     describe('global', function () {
       it('should access the global in the current environment', function () {
         expect(eval(stringify(global))).to.equal(global);


### PR DESCRIPTION
Add support for ES6 `Map` and `Set` by using `Array.from`.

Normally if `Map` and `Set` is available, `Array.from` should be available too. However, I guess one could have polyfills for some data types but not for the latter. So, I'm checking `Array.from` as well.