### PR TITLE
Add support for ES6 function notations

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "javascript-stringify.d.ts"
   ],
   "scripts": {
-    "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+    "test": "istanbul cover node_modules/mocha/bin/_mocha -x test.js -- -R spec"
   },
   "repository": "https://github.com/blakeembrey/javascript-stringify.git",
   "keywords": [

--- a/test.js
+++ b/test.js
@@ -83,6 +83,56 @@ describe('javascript-stringify', function () {
       );
     });
 
+    describe('functions', function () {
+      it(
+        'should reindent function bodies',
+        test(
+          function () {
+            if (true) {
+              return "hello";
+            }
+          },
+          'function () {\n  if (true) {\n    return "hello";\n  }\n}',
+          2
+        )
+      );
+
+      it(
+        'should reindent function bodies in objects',
+        test(
+          {
+            fn: function () {
+              if (true) {
+                return "hello";
+              }
+            }
+          },
+          '{\n  fn: function () {\n    if (true) {\n      return "hello";\n    }\n  }\n}',
+          2
+        )
+      );
+
+      it(
+        'should reindent function bodies in arrays',
+        test(
+          [
+            function () {
+              if (true) {
+                return "hello";
+              }
+            }
+          ],
+          '[\n  function () {\n    if (true) {\n      return "hello";\n    }\n  }\n]',
+          2
+        )
+      );
+
+      it(
+        'should not need to reindent one-liners',
+        testRoundTrip('{\n  fn: function () { return; }\n}', 2)
+      );
+    });
+
     describe('native instances', function () {
       describe('Date', function () {
         var date = new Date();
@@ -134,6 +184,20 @@ describe('javascript-stringify', function () {
 
         describe('arrow functions', function () {
           it('should stringify', testRoundTrip('(a, b) => a + b'));
+
+          it(
+            'should reindent function bodies',
+            test(
+              eval(
+'               (() => {\n' +
+'                 if (true) {\n' +
+'                   return "hello";\n' +
+'                 }\n' +
+'               })'),
+              '() => {\n  if (true) {\n    return "hello";\n  }\n}',
+              2
+            )
+          );
         });
 
         describe('generators', function () {
@@ -197,6 +261,22 @@ describe('javascript-stringify', function () {
             var fn = eval('({ *foo(x) { yield x; } })').foo;
             expect(stringify({ bar: fn })).to.equal('{bar:function* foo(x) { yield x; }}');
           });
+
+          it(
+            'should reindent methods',
+            test(
+              eval(
+'               ({\n' +
+'                 fn() {\n' +
+'                   if (true) {\n' +
+'                     return "hello";\n' +
+'                   }\n' +
+'                 }\n' +
+'               })'),
+              '{\n  fn() {\n    if (true) {\n      return "hello";\n    }\n  }\n}',
+              2
+            )
+          );
         });
       }
     });


### PR DESCRIPTION
This PR contains two improvements for stringifying functions. The first is support for ensuring that function values produced with the following ES6 function notations are stringified into valid code:
  * Arrow functions `(a, b) => a + b`
  * Generators `function* (x) { yield x; }`
  * Method notation `{ add(a, b) { return a + b; } }`

The second, which applies to all functions, improves function body indentation by removing extra indentation from function bodies before stringifying them, where extra indentation is determined by finding the line in the function body (after the first line) with the fewest initial space characters.