### PR TITLE
Don't quote Object.prototype keys

### DIFF
--- a/javascript-stringify.js
+++ b/javascript-stringify.js
@@ -78,7 +78,7 @@
    * @return {boolean}
    */
   function isValidVariableName (name) {
-    return !RESERVED_WORDS[name] && IS_VALID_IDENTIFIER.test(name);
+    return !RESERVED_WORDS.hasOwnProperty(name) && IS_VALID_IDENTIFIER.test(name);
   }
 
   /**

--- a/test.js
+++ b/test.js
@@ -67,6 +67,16 @@ describe('javascript-stringify', function () {
         'should stringify omit undefined keys',
         test({ a: true, b: undefined }, "{a:true}", null, { skipUndefinedProperties: true })
       );
+
+      it(
+        'should quote reserved word keys',
+        test({ "if": true, "else": false }, "{'if':true,'else':false}")
+      );
+
+      it(
+        'should not quote Object.prototype keys',
+        test({ "constructor": 1, "toString": 2 }, "{constructor:1,toString:2}")
+      );
     });
 
     describe('native instances', function () {


### PR DESCRIPTION
Keys on Object.prototype, such as `constructor` and `toString`, are not
reserved words and don't need to be quoted when they are used as object
keys.