### PR TITLE
Add test coverage

### DIFF
--- a/javascript-stringify.js
+++ b/javascript-stringify.js
@@ -195,9 +195,6 @@
     '[object Boolean]': function (boolean) {
       return 'new Boolean(' + boolean + ')';
     },
-    '[object Uint8Array]': function (array, indent) {
-      return 'new Uint8Array(' + stringifyArray(array) + ')';
-    },
     '[object Set]': function (array, indent, next) {
       if (typeof Array.from === 'function') {
         return 'new Set(' + stringify(Array.from(array), indent, next) + ')';

--- a/javascript-stringify.js
+++ b/javascript-stringify.js
@@ -196,14 +196,10 @@
       return 'new Boolean(' + boolean + ')';
     },
     '[object Set]': function (array, indent, next) {
-      if (typeof Array.from === 'function') {
-        return 'new Set(' + stringify(Array.from(array), indent, next) + ')';
-      } else return undefined;
+      return 'new Set(' + stringify(Array.from(array), indent, next) + ')';
     },
     '[object Map]': function (array, indent, next) {
-      if (typeof Array.from === 'function') {
-        return 'new Map(' + stringify(Array.from(array), indent, next) + ')';
-      } else return undefined;
+      return 'new Map(' + stringify(Array.from(array), indent, next) + ')';
     },
     '[object RegExp]': String,
     '[object Function]': String,

--- a/test.js
+++ b/test.js
@@ -99,6 +99,10 @@ describe('javascript-stringify', function () {
       describe('Error', function () {
         it('should stringify', test(new Error('test'), "new Error('test')"));
       });
+
+      describe('unknown native type', function () {
+        it('should be omitted', test({ k: process }, '{}'));
+      });
     });
 
     describe('ES6', function () {
@@ -182,6 +186,18 @@ describe('javascript-stringify', function () {
       var result = stringify(obj, null, null, { references: true })
 
       expect(result).to.equal('(function(){var x={a:{}};x.b=x.a;return x;}())');
+    });
+
+    it('should restore repeated values with indentation', function () {
+      var obj = {}
+      var child = {};
+
+      obj.a = child;
+      obj.b = child;
+
+      var result = stringify(obj, null, 2, { references: true })
+
+      expect(result).to.equal('(function () {\nvar x = {\n  a: {}\n};\nx.b = x.a;\nreturn x;\n}())');
     });
   });
 
@@ -298,6 +314,11 @@ describe('javascript-stringify', function () {
     it(
       'should get part of the object',
       test(obj, '{a:{b:{}}}', null, { maxDepth: 2 })
+    );
+
+    it(
+      'should get part of the object when tracking references',
+      test(obj, '{a:{b:{}}}', null, { maxDepth: 2, references: true })
     );
   });
 });


### PR DESCRIPTION
Increases statement and branch coverage of javascript-stringify.js to 100% by adding tests and removing old busted Uint8Array support and unnecessary checks for Array.from. (When paired with my other two pull requests, this brings the entire project up to :100:)

The Uint8Array code doesn't work on actual Uint8Arrays and is currently unused when handling Buffers (which is what I think it was originally there for?), so I just pulled it out.

The Array.from checks are unnecessary because the functions they were in are only called for native implementations of Map/Set (polyfill implementations, like instances of any user-defined function, will look like `[object Object]`), and if you have native Map/Set, you have Array.from.