### PR TITLE
Maintain key order when restoring references

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -682,7 +682,7 @@ describe("javascript-stringify", () => {
       const result = stringify(obj, null, null, { references: true });
 
       expect(result).toEqual(
-        "(function(){var x={key:'value'};x.obj=x;return x;}())"
+        "(function(){var x={key:'value',obj:undefined};x.obj=x;return x;}())"
       );
     });
 
@@ -727,7 +727,9 @@ describe("javascript-stringify", () => {
 
       const result = stringify(obj, null, null, { references: true });
 
-      expect(result).toEqual("(function(){var x={a:{}};x.b=x.a;return x;}())");
+      expect(result).toEqual(
+        "(function(){var x={a:{},b:undefined};x.b=x.a;return x;}())"
+      );
     });
 
     it("should restore repeated values with indentation", function() {
@@ -740,7 +742,22 @@ describe("javascript-stringify", () => {
       const result = stringify(obj, null, 2, { references: true });
 
       expect(result).toEqual(
-        "(function () {\nvar x = {\n  a: {}\n};\nx.b = x.a;\nreturn x;\n}())"
+        "(function () {\nvar x = {\n  a: {},\n  b: undefined\n};\nx.b = x.a;\nreturn x;\n}())"
+      );
+    });
+
+    it("should maintain key order when restoring repeated values", () => {
+      const obj: any = {};
+      const child = {};
+
+      obj.a = child;
+      obj.b = child;
+      obj.c = "C";
+
+      const result = stringify(obj, null, null, { references: true });
+
+      expect(result).toEqual(
+        "(function(){var x={a:{},b:undefined,c:'C'};x.b=x.a;return x;}())"
       );
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,8 @@ export function stringify(
           // Track nodes to restore later.
           if (tracking.has(value)) {
             unpack.set(path.slice(1), tracking.get(value)!);
-            return; // Avoid serializing referenced nodes on an expression.
+            // Use `undefined` as temporaray stand-in for referenced nodes
+            return valueToString(undefined, space, onNext, key);
           }
 
           // Track encountered nodes.


### PR DESCRIPTION
Currently, when called with `{ references: true }`, objects containing a repeated or circular reference will not have the property in question set until after the initialiser is done. This means that the key order may change from the original.

Now admittedly, the key order is not guaranteed by ECMAScript in the first place, but the fix that's required is really rather minimal; just put in an `undefined` value during the initialiser and replace that in the subsequent assignment. This would also make objects more closely match the current behaviour of arrays.