### PR TITLE
fix deprecated new Buffer()

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -247,7 +247,10 @@ describe("javascript-stringify", () => {
       });
 
       describeIf("Buffer", typeof (Buffer as any) === "function", () => {
-        it("should stringify", test(Buffer.from("test"), "new Buffer('test')"));
+        it(
+          "should stringify",
+          test(Buffer.from("test"), "Buffer.from('dGVzdA==', 'base64')")
+        );
       });
 
       describeIf("BigInt", typeof (BigInt as any) === "function", () => {

--- a/src/object.ts
+++ b/src/object.ts
@@ -8,7 +8,7 @@ import { arrayToString } from "./array";
  */
 export const objectToString: ToString = (value, space, next, key) => {
   if (typeof (Buffer as unknown) === "function" && Buffer.isBuffer(value)) {
-    return `new Buffer(${next(value.toString())})`;
+    return `Buffer.from(${next(value.toString("base64"))}, 'base64')`;
   }
 
   // Use the internal object string to select stringify method.


### PR DESCRIPTION
using `new Buffer()` is deprecated for a long time now
use `Buffer.from()` instead
also change the serialization format to `base64` to produce shorter
binary strings