### PR TITLE
fix: preserve a trailing hole in sparse arrays

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -15,6 +15,11 @@ export const arrayToString: ToString = (array: any[], space, next) => {
     })
     .join(space ? ",\n" : ",");
 
+  // A trailing hole is dropped by an array literal (`[1,]` has length `1`), so
+  // append a separator to preserve the array length on the round-trip.
+  const trailingHole =
+    array.length > 0 && !(array.length - 1 in array) ? "," : "";
+
   const eol = space && values ? "\n" : "";
-  return `[${eol}${values}${eol}]`;
+  return `[${eol}${values}${trailingHole}${eol}]`;
 };

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -101,6 +101,14 @@ describe("javascript-stringify", () => {
     describe("arrays", () => {
       it("should stringify as array shorthand", test([1, 2, 3], "[1,2,3]"));
 
+      it("should preserve a trailing hole", testRoundTrip("[1,,]"));
+
+      it("should preserve multiple trailing holes", testRoundTrip("[1,,,]"));
+
+      it("should preserve a leading hole", testRoundTrip("[,1]"));
+
+      it("should preserve an interior hole", testRoundTrip("[1,,3]"));
+
       it(
         "should indent elements",
         test([{ x: 10 }], "[\n\t{\n\t\tx: 10\n\t}\n]", "\t"),


### PR DESCRIPTION
## Problem

A sparse array whose last element is a hole loses that hole on a round-trip, so the array comes back shorter:

```js
import { stringify } from "javascript-stringify";

const value = [1, , ]; // length 2 (a hole at index 1)
stringify(value);       // "[1,]"
eval("(" + stringify(value) + ")").length; // 1  ← should be 2
```

Leading and interior holes are fine (`[,1]`, `[1,,3]`); only a trailing hole is dropped.

## Root cause

`arrayToString` maps the values (`Array.prototype.map` preserves holes) and joins them:

```js
const values = array.map(...).join(",");
return `[${eol}${values}${eol}]`;
```

`join` renders a hole as an empty string between separators, which works for leading and interior holes. But a trailing hole produces a single trailing comma — and `[1,]` is a length-1 array literal, so the hole is lost.

## Fix

When the last element is a hole, append one more separator so the array literal keeps its length (`[1,,]` has length 2):

```js
const trailingHole =
  array.length > 0 && !(array.length - 1 in array) ? "," : "";
return `[${eol}${values}${trailingHole}${eol}]`;
```

## Test plan

- Added round-trip tests for trailing, leading and interior holes (the two trailing-hole cases fail on `main`, the others already passed).
- Full suite green (150).
