### PR TITLE
fix: keep `__proto__` keys as own properties

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -134,6 +134,11 @@ describe("javascript-stringify", () => {
         "should not quote Object.prototype keys",
         test({ constructor: 1, toString: 2 }, "{constructor:1,toString:2}"),
       );
+
+      it(
+        "should keep `__proto__` keys as own properties",
+        testRoundTrip("{['__proto__']:42}"),
+      );
     });
 
     describe("functions", () => {

--- a/src/quote.ts
+++ b/src/quote.ts
@@ -77,6 +77,9 @@ export function isValidVariableName(name: PropertyKey): name is string {
  * Quote JavaScript key access.
  */
 export function quoteKey(key: PropertyKey, next: Next) {
+  // `__proto__` as an identifier or string key is the prototype setter rather
+  // than an own property; emit it as a computed key so it round-trips.
+  if (key === "__proto__") return `[${next(key)}]`;
   return isValidVariableName(key) ? key : next(key);
 }
 


### PR DESCRIPTION
## Problem

An own `__proto__` property is dropped on a round-trip:

```js
import { stringify } from "javascript-stringify";

const value = JSON.parse('{"__proto__": 42, "a": 1}'); // own enumerable __proto__
stringify(value); // "{__proto__:42,a:1}"

const back = eval("(" + stringify(value) + ")");
Object.getOwnPropertyDescriptor(back, "__proto__"); // undefined  ← lost
```

`{ __proto__: 42 }` in an object literal is the prototype setter, not an own property, so the entry disappears (and a `__proto__` value that is an object even changes the result's prototype, which then breaks re-stringifying it).

## Root cause

`quoteKey` emits `__proto__` as a bare identifier (it is a valid identifier name), producing the prototype-setter form. A quoted string key (`"__proto__"`) would behave the same way — only a computed key creates an own property.

## Fix

Emit `__proto__` as a computed key:

```js
export function quoteKey(key: PropertyKey, next: Next) {
  if (key === "__proto__") return `[${next(key)}]`;
  return isValidVariableName(key) ? key : next(key);
}
```

`{['__proto__']:42}` is an own property and leaves the prototype untouched, matching `JSON.parse`/`structuredClone`. Other keys (including `constructor`, `toString`) are unaffected.

## Test plan

- Added a round-trip test for an own `__proto__` key (fails on `main`, passes with the fix).
- Full suite green (147).
